### PR TITLE
fix: update static web app output folder

### DIFF
--- a/.github/workflows/azure-static-web-apps-ambitious-dune-0254ba11e.yml
+++ b/.github/workflows/azure-static-web-apps-ambitious-dune-0254ba11e.yml
@@ -30,7 +30,7 @@ jobs:
           # For more information regarding Static Web App workflow configurations, please visit: https://aka.ms/swaworkflowconfig
           app_location: "/" # App source code path
           api_location: "" # Api source code path - optional
-          output_location: "build" # Built app content directory - optional
+          output_location: "dist" # Built app content directory - optional
           ###### End of Repository/Build Configurations ######
 
   close_pull_request_job:


### PR DESCRIPTION
## Summary
- ensure Azure Static Web Apps workflow uploads the `dist` folder generated by Vite

## Testing
- `npm run lint` *(fails: 'Award' is defined but never used; 'useEffect' and 'useRef' are defined but never used)*

------
https://chatgpt.com/codex/tasks/task_e_6895a40efe848322a3584b6a66b04c76