### PR TITLE
fix: load images correctly

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { Link, useLocation } from 'react-router-dom';
 import { Menu, X } from 'lucide-react';
+import logo from '../assets/LCG_Logo.avif';
 
 const Navbar = () => {
   const [isOpen, setIsOpen] = useState(false);
@@ -27,10 +28,10 @@ const Navbar = () => {
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="flex justify-between items-center">
           <Link to="/" className="flex items-center group">
-            <img 
-              src="/src/assets/LCG_Logo.avif" 
-              alt="LexComp Global Logo" 
-             className="h-24 w-auto transition-transform duration-300 group-hover:scale-110"
+            <img
+              src={logo}
+              alt="LexComp Global Logo"
+              className="h-24 w-auto transition-transform duration-300 group-hover:scale-110"
             />
           </Link>
 

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useRef } from 'react';
 import { ArrowRight, Shield, FileCheck, Users, Lock } from 'lucide-react';
 import { Link } from 'react-router-dom';
+import banner from '../assets/lcg-banner.jpg';
 
 const Home = () => {
 
@@ -10,7 +11,7 @@ const Home = () => {
       <div 
         className="relative min-h-screen flex items-center justify-center bg-no-repeat bg-cover bg-center bg-fixed"
         style={{
-          backgroundImage: `url('/src/assets/lcg-banner.jpg')`
+          backgroundImage: `url(${banner})`
         }}
       >
         


### PR DESCRIPTION
## Summary
- load images using imports rather than absolute /src paths
- wire hero banner using imported asset

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6895a5806a2483228f058aecd5bd2fbe